### PR TITLE
Make water meters configurable

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,30 @@
+name: Build image and push to Docker Hub
+
+on:
+    push:
+        branches:
+            - "main"
+    pull_request:
+        branches:
+            - "main"
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v2
+            - name: Login to Docker Hub
+              uses: docker/login-action@v2
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and push
+              uses: docker/build-push-action@v3
+              with:
+                  file: docker/Dockerfile
+                  platforms: linux/amd64
+                  push: true
+                  tags: giantmolecularcloud/water-monitoring:latest

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Run the app in Streamlit:
 ## docker
 
 Build the image:  
-`docker build -t water-monitoring:0.1 -f docker/Dockerfile .`
+`docker build -t water-monitoring:latest -f docker/Dockerfile .`
 
 Run the container:  
-`docker run -p 8501:8501 water-monitoring:0.1 water-monitoring`
+`docker run -p 8501:8501 -v /path/to/your/config/directory:/config water-monitoring:latest water-monitoring`
 
 ## Options
 
@@ -35,6 +35,18 @@ When no variables are given, the following defaults are assumed:
 | DB_NAME       | 'water-monitoring' |
 | TIMEZONE      | 'Europe/Berlin'    |
 | DEBUG         | False              |
+
+## Water meter configuration
+
+The water meters are configured in a yaml config file, see `config/config.yaml` for an example.
+An umlimited number of rooms with each an unlimited number of water meters is supported.
+The structure is as follows:
+
+-   rooms: list of rooms
+-   each room must be given a name and a list of water meters
+-   each water meter has an ID, name and offset. The offset is added to the actual meter readings to get coherent measurements when the meter is replaced.
+
+The app expects the config file to be located in `config/config.yaml`. When run in docker, your config must therefore be passed through with a `volume` argument.
 
 ## Frontend
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,46 @@
+import logging
+from pathlib import Path
+from typing import List
+
+import yaml
+from pydantic import BaseModel, StrictInt, StrictStr, root_validator, validator
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s -  %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("config")
+
+
+class MeterConfig(BaseModel):
+    id: int
+    name: str
+    offset: float = 0
+
+
+class RoomConfig(BaseModel):
+    name: StrictStr
+    meters: List[MeterConfig]
+
+
+class RoomsConfig(BaseModel):
+    rooms: List[RoomConfig]
+
+
+def get_config(configfile: Path) -> RoomsConfig:
+    """
+    Parse the config file into a Pydantic model.
+
+    Parameters
+    ----------
+    configfile : str
+        Path to the config file including file name and extension.
+
+    Returns
+    -------
+    ShellyInfluxConfig
+        Parsed and validated config.
+    """
+
+    if configfile.suffix not in [".yaml", ".yml"]:
+        raise ValueError("Config file must be YAML with suffix .yaml or .yml")
+    with open(configfile) as f:
+        config = yaml.safe_load(f)
+        return RoomsConfig(**config)

--- a/app/water-monitoring.py
+++ b/app/water-monitoring.py
@@ -3,7 +3,7 @@
 A little streamlit frontend to log manual water meter readings to a InfluxDB backend.
 
 Author: GiantMolecularCloud
-Version: 0.2
+Version: 0.3
 """
 
 import logging

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,17 @@
+rooms:
+    - name: "bathroom"
+      meters:
+          - id: 0
+            name: "cold"
+            offset: 0.0
+          - id: 1
+            name: "hot"
+            offset: 0.0
+    - name: "kitchen"
+      meters:
+          - id: 0
+            name: "cold"
+            offset: 0.0
+          - id: 1
+            name: "hot"
+            offset: 0.0

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,2 +1,4 @@
 streamlit
 influxdb
+pyyaml
+pydantic


### PR DESCRIPTION
The old version had two rooms with two water meters each hardcoded. This new version allows to configure the number of rooms, water meters and their names. A new parameter allows to offset the readings after a meter has been replaced.